### PR TITLE
docs: adiciona visão geral do planejamento no board GitHub Projects 🧭

### DIFF
--- a/docs/issue-01-drizzle-db.md
+++ b/docs/issue-01-drizzle-db.md
@@ -1,0 +1,35 @@
+# 📌 Issue 01 – Configurar conexão com banco de dados (Drizzle + PostgreSQL)
+
+## 🎯 Objetivo
+
+Implementar a camada de **persistência** da aplicação utilizando o **Drizzle ORM** com **PostgreSQL**, modelando as entidades principais do domínio da clínica para viabilizar funcionalidades como cadastro de médicos, pacientes, agendamentos e multi-clínicas por usuário.
+
+---
+
+## 📚 Tarefas
+
+### 🔧 Setup
+- [x] 📦 Instalar dependências: `drizzle-orm`, `pg`, `drizzle-kit`
+- [x] 🛠 Criar arquivo `drizzle.config.ts` com schema, out e driver PostgreSQL
+- [x] 🧪 Criar `.env.example` com `DATABASE_URL`
+
+### 🗃️ Modelagem
+- [x] 🏥 Criar `clinics` com timestamps e campos básicos
+- [x] 👤 Criar `users` com chave UUID
+- [x] 🔗 Criar `users_to_clinics` (N:N entre users e clinics)
+- [x] 🩺 Criar `doctors` com disponibilidade e preço
+- [x] 🧍 Criar `patients` com sexo, email e telefone
+- [x] 📅 Criar `appointments` com ligação a doctor, patient e clinic
+- [x] 🧭 Definir enum `patient_sex` (`male`, `female`)
+- [x] 🔄 Definir relações entre tabelas com `relations()`
+
+### 🚀 Execução
+- [x] 🧬 Criar `src/db/index.ts` com client PostgreSQL
+- [x] ⬆️ Executar `drizzle-kit push` para aplicar as tabelas no banco (Neon)
+- [ ] 🧪 Validar estrutura no Drizzle Studio (visualização do schema)
+
+---
+
+🧩 **Referência interna:** `#1`  
+📂 **Branch:** `feat/database-setup`  
+📝 **Responsável:** @vivianezzt

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,34 @@
+# 📋 Visão geral — Clinic Schedule (GitHub Projects)
+
+Este documento acompanha o planejamento visual do sistema `clinic_schedule`, representado no board de projeto do GitHub.
+
+## 🔍 Sobre o projeto
+
+Sistema completo de agendamento clínico com gestão de pacientes, médicos e clínicas.
+
+**Tecnologias utilizadas:**
+- 📦 Next.js com TypeScript
+- 🎨 Tailwind CSS para estilização
+- 🧠 PostgreSQL + Drizzle ORM para modelagem relacional
+- 🛠 ESLint, Prettier, Husky e lint-staged para padronização
+- 🔐 Autenticação planejada e painel administrativo futuro
+
+## 📌 Organização do board
+
+O board é dividido nas seguintes colunas:
+
+- **📋 Backlog** — tarefas planejadas mas ainda não iniciadas
+- **🚧 Em andamento** — tarefas em desenvolvimento ativo
+- **🧪 Em revisão** — aguardando análise/revisão de PRs ou testes
+- **✅ Concluído** — tarefas finalizadas e integradas à main
+
+## 🔗 Referências e links úteis
+
+- [📁 Repositório principal](https://github.com/vivianezzt/clinic-schedule)
+- [🧾 Issues](https://github.com/vivianezzt/clinic-schedule/issues)
+- [🚀 Pull Requests](https://github.com/vivianezzt/clinic-schedule/pulls)
+- [📊 Projeto no GitHub Projects](https://github.com/users/vivianezzt/projects)
+
+---
+
+Este documento ajuda a rastrear o progresso geral e manter alinhamento com o roadmap planejado.


### PR DESCRIPTION
## 📋 Descrição

Este Pull Request adiciona o arquivo `docs/project-overview.md`, contendo a documentação completa da estrutura utilizada no board de planejamento do GitHub Projects para o sistema `clinic_schedule`.

O documento tem como objetivo fornecer clareza e rastreabilidade sobre o processo de desenvolvimento, detalhando as colunas do board, seu uso estratégico, e os recursos complementares que conectam planejamento e execução no repositório.

---

## ✅ Conteúdo incluído

- Criação do arquivo `docs/project-overview.md`
- Explicação da função de cada coluna do board:
  - 📋 Backlog
  - 🚧 Em andamento
  - 🧪 Em revisão
  - ✅ Concluído
- Inclusão de links úteis:
  - Repositório
  - Issues
  - Pull Requests
  - GitHub Projects
- Apresentação das tecnologias utilizadas no projeto
- Contexto para uso colaborativo e rastreável

---

## 🔗 Issue relacionada

Closes #1 